### PR TITLE
Add tests for Set, Seq.Indexed

### DIFF
--- a/index-test.js
+++ b/index-test.js
@@ -62,6 +62,54 @@ describe('expect immutable', () => {
     it('does not throw when Lists are the same', () => {
       expect(Immutable.List([1])).toEqualImmutable(Immutable.List([1]));
     });
+
+    it('throws when Sets are different', () => {
+      expect(() =>
+        expect(Immutable.Set([])).toEqualImmutable(Immutable.Set([1]))
+      ).toThrow(
+        'Expected [] to equal [ 1 ]'
+      );
+    });
+
+    it('does not throw when empty Sets are compared', () => {
+      expect(Immutable.Set([])).toEqualImmutable(Immutable.Set([]));
+    });
+
+    it('does not throw when Sets are the same', () => {
+      expect(Immutable.Set([1])).toEqualImmutable(Immutable.Set([1]));
+    });
+
+    it('throws when Seq.Indexed are different', () => {
+      expect(() =>
+        expect(Immutable.Seq([])).toEqualImmutable(Immutable.Seq([1]))
+      ).toThrow(
+        'Expected [] to equal [ 1 ]'
+      );
+    });
+
+    it('does not throw when empty Seq.Indexed are compared', () => {
+      expect(Immutable.Seq([])).toEqualImmutable(Immutable.Seq([]));
+    });
+
+    it('does not throw when Seq.Indexed are the same', () => {
+      expect(Immutable.Seq([1])).toEqualImmutable(Immutable.Seq([1]));
+    });
+
+    it('throws when Seq.Indexed are different', () => {
+      expect(() =>
+        expect(Immutable.Seq([])).toEqualImmutable(Immutable.Seq([1]))
+      ).toThrow(
+        'Expected [] to equal [ 1 ]'
+      );
+    });
+
+    it('does not throw when empty Seq.Indexed are compared', () => {
+      expect(Immutable.Seq([])).toEqualImmutable(Immutable.Seq([]));
+    });
+
+    it('does not throw when Seq.Indexed are the same', () => {
+      expect(Immutable.Seq([1])).toEqualImmutable(Immutable.Seq([1]));
+    });
   });
 
   context('toNotEqualImmutable', () => {
@@ -100,6 +148,30 @@ describe('expect immutable', () => {
     it('throws when Lists are the same', () => {
       expect(() =>
         expect(Immutable.List([1])).toNotEqualImmutable(Immutable.List([1]))
+      ).toThrow(
+        'Expected [ 1 ] to not equal [ 1 ]'
+      );
+    });
+
+    it('does not throw when Sets are different', () => {
+      expect(Immutable.Set([1])).toNotEqualImmutable(Immutable.Set([]));
+    });
+
+    it('throws when Sets are the same', () => {
+      expect(() =>
+        expect(Immutable.Set([1])).toNotEqualImmutable(Immutable.Set([1]))
+      ).toThrow(
+        'Expected [ 1 ] to not equal [ 1 ]'
+      );
+    });
+
+    it('does not throw when Seq.Indexed are different', () => {
+      expect(Immutable.Seq([1])).toNotEqualImmutable(Immutable.Seq([]));
+    });
+
+    it('throws when Seq.Indexed are the same', () => {
+      expect(() =>
+        expect(Immutable.Seq([1])).toNotEqualImmutable(Immutable.Seq([1]))
       ).toThrow(
         'Expected [ 1 ] to not equal [ 1 ]'
       );


### PR DESCRIPTION
Hey. Thanks for making this project. I think it's an important one. :)

I've copied the tests you wrote for Map/List for Seq.Indexed and Set. Looks like `toEqualImmutable` and `toNotEqualImmutable` work for those as well. Let me know if you're interested in this PR and I can also change the README to reflect the support for them as well.

Thanks!